### PR TITLE
Support basic compilation and execution on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all debug install install-fonts uninstall uninstall-fonts
+.PHONY: all debug test install install-fonts uninstall uninstall-fonts
 PREFIX ?= /usr
 
 all:
@@ -6,8 +6,12 @@ all:
 debug:
 	shards build --debug -Dpreview_mt
 test:
-	# Some tests need en_US locale to pass on string to float convertions: "1.23" vs "1,23".
-	GC_DONT_GC=1 LC_ALL=en_US.UTF8 xvfb-run crystal spec
+  # Some tests need en_US locale to pass on string to float convertions: "1.23" vs "1,23".
+	@if [ "$$(uname -s)" == "Darwin" ]; then
+		GC_DONT_GC=1 crystal spec; \
+	else \
+		GC_DONT_GC=1 LC_ALL=en_US.UTF8 xvfb-run crystal spec; \
+	fi
 
 install:
 	install -D -m 0755 bin/tijolo $(DESTDIR)$(PREFIX)/bin/tijolo

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to create a package from git, clone the repository then run `./packa
 a docker image, build Tijolo inside that image, create a debian package then copy it back, out of the container. Not best
 approach to build a deb package but works on non-deb machines.
 
-## Compiling from source
+## Dependencies
 
 You will need:
 
@@ -62,7 +62,31 @@ You will need:
  - [libGit2](https://libgit2.org/).
  - [editorconfig-core](https://github.com/editorconfig/editorconfig-core-c).
 
-Then the usual:
+### via apt
+
+```shell
+$ sudo apt-get install -y \
+    git make crystal libeditorconfig-dev \
+    libgirepository1.0-dev libgit2-dev \
+    libgtksourceview-4-dev libvte-2.91-dev libyaml-dev
+```
+
+Names and versions may differ depending on distro and version
+
+### via Homebrew/Linuxbrew
+
+```shell
+$ brew install crystal gtk+3 gobject-introspection gtksourceview4 vte3 \
+               libgit2 editorconfig
+```
+
+### Other package managers
+
+Check your distro's package managers for the equivalent package names. You will
+need the install the `-dev` or `-devel` equivalent packages, in addition to the
+runtime packages.
+
+## Compiling from Source
 
 ```
 $ make

--- a/src/helper.cr
+++ b/src/helper.cr
@@ -18,7 +18,8 @@ def relative_path_label(path : Path, project_path : Path? = nil) : String
 end
 
 def usr_share_paths(dir : String, paths = [] of String)
-  usr_path = Path[File.readlink("/proc/self/exe"), "../../"]
+  exe_path = Process.executable_path || raise AppError.new("Cannot find executable path")
+  usr_path = Path[exe_path, "../../"]
 
   paths.unshift(usr_path.join("./share/tijolo/#{dir}/").expand.to_s)
   paths.unshift(usr_path.join("./local/share/tijolo/#{dir}/").expand.to_s)


### PR DESCRIPTION
Adds documentation for installing dependencies and makes tijolo compile and run on macOS

Spec suite passes. I didn't test it a ton, but clicked around a bit. It's a bit sluggish in rendering currently, but I'm not sure if that's just the state of GTK3 on macOS these days or if there's some optimization to be done (a GTK+ issue makes it sound as though GTK3 [might just be slow on macOS](https://gitlab.gnome.org/GNOME/gtk/-/issues/3714))

(a little small on the High DPI display, so maybe there's a scaling setting missing somewhere)

<img width="1139" alt="Screen Shot 2021-09-04 at 3 40 08 PM" src="https://user-images.githubusercontent.com/354236/132111821-6cefb72f-f671-4e90-8690-abe049af8d2f.png">

Closes #6 