### PR TITLE
Pass "-Wl,--as-needed" linker flags to prevent overlinking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX ?= /usr
 CR_FLAGS ?= -Dpreview_mt -Dstrict_multi_assign -Duse_pcre2 -Dpreview_overload_order
 
 all: .WAIT configure
-	shards build --release -Dpreview_mt $(CR_FLAGS) -s
+	shards build --release -Dpreview_mt $(CR_FLAGS) -s --link-flags='-Wl,--as-needed'
 
 configure:
 	shards install


### PR DESCRIPTION
This fixes #18 