### PR TITLE
Add option to disable hexeditor support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Generate bindings
         run: ./bin/gi-crystal
       - name: Compile
-        run: shards build ${{ matrix.flags }} -s
+        run: shards build ${{ matrix.flags }} -s -Dno_hexeditor
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: crystal spec ${{ matrix.flags }} -v
+          run: crystal spec ${{ matrix.flags }} -v -Dno_hexeditor

--- a/src/hex_view.cr
+++ b/src/hex_view.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:no_hexeditor) %}
+
 GICrystal.require("Hex", "4")
 
 class HexView < DocumentView

--- a/src/view_factory.cr
+++ b/src/view_factory.cr
@@ -8,7 +8,11 @@ class ViewFactory
     if image?(resource)
       raise TijoloError.new("Image files are not supported yet 😅.")
     elsif elf?(resource)
-      HexView.new(resource, project)
+      {% if flag?(:no_hexeditor) %}
+        raise TijoloError.new("Tijolo was compiled without support for an hexeditor 😢.")
+      {% else %}
+        HexView.new(resource, project)
+      {% end %}
     else
       TextView.new(resource, project)
     end


### PR DESCRIPTION
The GHex package on Ubuntu doesn't ship the Gir files, so I can't build it on CI.